### PR TITLE
Add service account configuration for costmanagement-metrics-operator…

### DIFF
--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-12-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-12
+
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
+
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-push.yaml
@@ -36,7 +36,7 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
+
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-12-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-12-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-12
+
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-13-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-13-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-13-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-13
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +40,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-13-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-13-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-13-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-13
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -33,7 +36,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-14-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-14-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-14-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-14
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +40,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-14-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-14-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-14-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-14
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -33,7 +36,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-15-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-15-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-15-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-15
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +40,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-15-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-15-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-15-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-15
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -33,7 +36,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-16-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-16-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-16-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-16
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +40,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-16-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-16-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-16-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-16
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -33,7 +36,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-17-pull-request.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-17-pull-request.yaml
@@ -18,6 +18,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-17-on-pull-request
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-17
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -37,7 +40,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/costmanagement-metrics-operator-fbc-component-v4-17-push.yaml
+++ b/.tekton/costmanagement-metrics-operator-fbc-component-v4-17-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: costmanagement-metrics-operator-fbc-component-v4-17-on-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-fbc-component-v4-17
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -33,7 +36,6 @@ spec:
       - linux/ppc64le
   pipelineRef:
     name: pipeline-build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
…-fbc-component

## Summary by Sourcery

Configure Tekton pipeline triggers to use a dedicated service account for costmanagement-metrics-operator-fbc-component build tasks across versions 4-12 through 4-17.

Enhancements:
- Add specific serviceAccountName entries to taskRunTemplate in pull-request and push pipeline YAMLs for versions v4-12 through v4-17
- Remove empty taskRunTemplate placeholders from pipeline trigger definitions