### PR TITLE
[COST-6470] Add dockefile for OCP 4.18

### DIFF
--- a/Dockerfile.v4-18
+++ b/Dockerfile.v4-18
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD catalog/costmanagement-metrics-operator /configs/costmanagement-metrics-operator
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 File-Based Catalog for Cost Management Metrics Operator
 
-**note**: the catalogs differ depending on OCP version:
-* 4.16 or earlier, bundle metadata must use the olm.bundle.object format
-* 4.17 or later, bundle metadata must use the olm.csv.metadata format
-The catalog for <=4.16 is stored in [catalog-old](catalog-old), whereas >=4.17 is stored in [catalog](catalog)
+**NOTE**: The catalog and bundle metadata format are dependent on the OCP version:
+
+  * **OCP >= 4.17:**
+      * The catalog is stored in [catalog](catalog).
+      * Bundle metadata must use the `olm.csv.metadata` format.
+
+  * **OCP <= 4.16:**
+      * The catalog is stored in [catalog-old](catalog-old).
+      * Bundle metadata must use the `olm.bundle.object` format.
 
 ## How to update
 


### PR DESCRIPTION
## Summary by Sourcery

Provide support for OCP 4.18 by introducing a dedicated Dockerfile and enhance the README to clearly document catalog and metadata format requirements for different OCP releases

New Features:
- Add Dockerfile for OCP 4.18

Documentation:
- Clarify README instructions and formatting for catalog storage and bundle metadata across OCP versions