### PR TITLE
[COST-6619] Add dockerfile for OCP 4.19

### DIFF
--- a/Dockerfile.v4-19
+++ b/Dockerfile.v4-19
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD catalog/costmanagement-metrics-operator /configs/costmanagement-metrics-operator
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add a Dockerfile for building OCP 4.19 images