### PR TITLE
[COST-6093] Release version 4.0.0 cost management metrics operator

### DIFF
--- a/releases/costmanagement-metrics-operator-4.0.0.yaml
+++ b/releases/costmanagement-metrics-operator-4.0.0.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: "rh-ee-dnakabaa"
+  namespace: cost-mgmt-dev-tenant
+  name: costmanagement-metrics-operator-4.0.0-prod-1
+spec:
+  releasePlan: costmanagement-metrics-operator
+  snapshot: costmanagement-metrics-operator-5lszl
+  data:
+    releaseNotes:
+      type: RHEA
+      topic: "Cost Management Metrics Operator version 4.0.0 release."
+      issues:
+        fixed:
+          - id: COST-6058
+            source: issues.redhat.com
+          - id: COST-6010
+            source: issues.redhat.com


### PR DESCRIPTION
- Release snapshot containing operator and bundle images

## Summary by Sourcery

Promote costmanagement-metrics-operator to version 4.0.0 by adding a new Release resource snapshot

New Features:
- Add Release manifest for costmanagement-metrics-operator v4.0.0 snapshot

Deployment:
- Include release notes referencing fixed issues COST-6058 and COST-6010