### PR TITLE
[COST-6093] Release version 4.0.0 FBC  images

### DIFF
--- a/releases/costmanagement-metrics-operator-fbc-4.0.0.yaml
+++ b/releases/costmanagement-metrics-operator-fbc-4.0.0.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+
+  name: costmanagement-metrics-operator-prod-fbc-v4-12-nk6g5-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-12
+  snapshot: costmanagement-metrics-operator-fbc-v4-12-nk6g5
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-13-5bsth-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-13
+  snapshot: costmanagement-metrics-operator-fbc-v4-13-5bsth
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-14-bbbtt-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-14
+  snapshot: costmanagement-metrics-operator-fbc-v4-14-bbbtt
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-15-4wctd-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-15
+  snapshot: costmanagement-metrics-operator-fbc-v4-15-4wctd
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-16-rm224-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-16
+  snapshot: costmanagement-metrics-operator-fbc-v4-16-rm224
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-17-d7x2f-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-17
+  snapshot: costmanagement-metrics-operator-fbc-v4-17-d7x2f
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-18-hqrb2-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-18
+  snapshot: costmanagement-metrics-operator-fbc-v4-18-hqrb2
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
+    release.appstudio.openshift.io/version: '4.0.0'
+    release.appstudio.openshift.io/sha: 'd7f2d09eb70a52483b12d2ef006de292090b2fb6'
+  name: costmanagement-metrics-operator-prod-fbc-v4-19-zm4ct-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-19
+  snapshot: costmanagement-metrics-operator-fbc-v4-19-zm4ct


### PR DESCRIPTION
Release file-based catalogs for cost management metrics operator version 4.0.0 


Depends on: 
* https://github.com/project-koku/cost-management-metrics-operator-fbc/pull/60

## Summary by Sourcery

Enhancements:
- Add AppStudio Release definitions for costmanagement-metrics-operator-fbc version 4.0.0 across release plans v4-12 through v4-19