### PR TITLE
[COST-6828] Release FBCs for version 4.2.0

### DIFF
--- a/releases/costmanagement-metrics-operator-fbc-4.2.0.yaml
+++ b/releases/costmanagement-metrics-operator-fbc-4.2.0.yaml
@@ -49,7 +49,7 @@ metadata:
     release.appstudio.openshift.io/author: 'rh-ee-dnakabaa'
     release.appstudio.openshift.io/version: '4.2.0'
     release.appstudio.openshift.io/sha: '6ae051ff4944895998b18b6b3b51af89742f3fa5'
-  name: costmanagement-metrics-operator-prod-fbc-v4-15-xhcts-2
+  name: costmanagement-metrics-operator-prod-fbc-v4-15-xhcts-3
   namespace: cost-mgmt-dev-tenant
 spec:
   releasePlan: costmanagement-metrics-operator-fbc-v4-15


### PR DESCRIPTION
## Depends on:

* https://github.com/project-koku/cost-management-metrics-operator-fbc/pull/74

## Summary by Sourcery

Deployment:
- Add AppStudio Release definitions for costmanagement-metrics-operator FBC v4.2.0 for OpenShift 4.12–4.20