### PR TITLE
[COST-7375] add v4.4.1 operator and FBC releases

### DIFF
--- a/releases/4.4.1/costmanagement-metrics-operator-4.4.1.yaml
+++ b/releases/4.4.1/costmanagement-metrics-operator-4.4.1.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: "rh-ee-lbacciot"
+  namespace: cost-mgmt-dev-tenant
+  name: costmanagement-metrics-operator-4.4.1-prod-1
+spec:
+  releasePlan: costmanagement-metrics-operator
+  snapshot: costmanagement-metrics-operator-20260609-072014-000
+  data:
+    releaseNotes:
+      type: RHSA
+      topic: "Cost Management Metrics Operator version 4.4.1 release."
+      issues:
+        fixed:
+          - id: COST-7474
+            source: issues.redhat.com
+          - id: COST-7484
+            source: issues.redhat.com
+          - id: COST-7668
+            source: issues.redhat.com
+      cves:
+        - key: CVE-2026-4878
+          component: costmanagement-metrics-operator
+          packages:
+            - libcap
+        - key: CVE-2026-31790
+          component: costmanagement-metrics-operator
+          packages:
+            - openssl
+        - key: CVE-2026-2100
+          component: costmanagement-metrics-operator
+          packages:
+            - p11-kit
+        - key: CVE-2026-4437
+          component: costmanagement-metrics-operator
+          packages:
+            - glibc
+        - key: CVE-2026-4438
+          component: costmanagement-metrics-operator
+          packages:
+            - glibc
+        - key: CVE-2026-4046
+          component: costmanagement-metrics-operator
+          packages:
+            - glibc
+        - key: CVE-2026-28390
+          component: costmanagement-metrics-operator
+          packages:
+            - openssl
+      references:
+        - https://access.redhat.com/security/updates/classification
+        - https://access.redhat.com/security/cve/CVE-2026-4878
+        - https://access.redhat.com/security/cve/CVE-2026-31790
+        - https://access.redhat.com/security/cve/CVE-2026-2100
+        - https://access.redhat.com/security/cve/CVE-2026-4437
+        - https://access.redhat.com/security/cve/CVE-2026-4438
+        - https://access.redhat.com/security/cve/CVE-2026-4046
+        - https://access.redhat.com/security/cve/CVE-2026-28390
+        - https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html/getting_started_with_cost_management/steps-to-cost-management

--- a/releases/4.4.1/costmanagement-metrics-operator-fbc-4.4.1.yaml
+++ b/releases/4.4.1/costmanagement-metrics-operator-fbc-4.4.1.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+
+  name: costmanagement-metrics-operator-fbc-v4-12-20260611-154218-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-12
+  snapshot: costmanagement-metrics-operator-fbc-v4-12-20260611-154218-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-13-20260611-154225-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-13
+  snapshot: costmanagement-metrics-operator-fbc-v4-13-20260611-154225-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-14-20260611-154210-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-14
+  snapshot: costmanagement-metrics-operator-fbc-v4-14-20260611-154210-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-15-20260611-154219-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-15
+  snapshot: costmanagement-metrics-operator-fbc-v4-15-20260611-154219-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-16-20260611-154157-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-16
+  snapshot: costmanagement-metrics-operator-fbc-v4-16-20260611-154157-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-17-20260611-154207-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-17
+  snapshot: costmanagement-metrics-operator-fbc-v4-17-20260611-154207-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-18-20260611-154150-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-18
+  snapshot: costmanagement-metrics-operator-fbc-v4-18-20260611-154150-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-19-20260611-154227-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-19
+  snapshot: costmanagement-metrics-operator-fbc-v4-19-20260611-154227-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-20-20260611-154151-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-20
+  snapshot: costmanagement-metrics-operator-fbc-v4-20-20260611-154151-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-21-20260611-154115-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-21
+  snapshot: costmanagement-metrics-operator-fbc-v4-21-20260611-154115-000
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  labels:
+    release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
+    release.appstudio.openshift.io/version: '4.4.1'
+    release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
+  name: costmanagement-metrics-operator-fbc-v4-22-20260611-154227-000-1
+  namespace: cost-mgmt-dev-tenant
+spec:
+  releasePlan: costmanagement-metrics-operator-fbc-v4-22
+  snapshot: costmanagement-metrics-operator-fbc-v4-22-20260611-154227-000

--- a/releases/4.4.1/costmanagement-metrics-operator-fbc-4.4.1.yaml
+++ b/releases/4.4.1/costmanagement-metrics-operator-fbc-4.4.1.yaml
@@ -147,7 +147,7 @@ metadata:
     release.appstudio.openshift.io/author: 'rh-ee-lbacciot'
     release.appstudio.openshift.io/version: '4.4.1'
     release.appstudio.openshift.io/sha: '04ba7172fe7a00785bd22443d5641c0acb9417b9'
-  name: costmanagement-metrics-operator-fbc-v4-22-20260611-154227-000-1
+  name: costmanagement-metrics-operator-fbc-v4-22-20260611-154227-000-2
   namespace: cost-mgmt-dev-tenant
 spec:
   releasePlan: costmanagement-metrics-operator-fbc-v4-22


### PR DESCRIPTION
## Summary

- Operator release (RHSA): snapshot `costmanagement-metrics-operator-20260609-072014-000`
- FBC releases for OCP v4.12–v4.22: 11 snapshots from `20260611` (git sha `04ba7172`)
- 7 CVEs addressed: `CVE-2026-4878` (libcap), `CVE-2026-31790` (openssl), `CVE-2026-2100` (p11-kit), `CVE-2026-4437`, `CVE-2026-4438`, `CVE-2026-4046` (glibc), `CVE-2026-28390` (openssl)
- Bug fixes: COST-7474, COST-7484, COST-7668

## Checklist

- [x] Operator snapshot verified in Konflux
- [x] All 11 FBC snapshots verified via `oc get snapshot -l pac.test.appstudio.openshift.io/sha=04ba7172...`
- [ ] CVEs cross-checked against catalog.redhat.com security tab
- [ ] David review

Made with [Cursor](https://cursor.com)